### PR TITLE
Adjusting the output in test-divergence.

### DIFF
--- a/tester.scm
+++ b/tester.scm
@@ -33,7 +33,7 @@
   (syntax-rules ()
     ((_ title tested-expression)
      (begin
-       (cout "Testing ~s (engine with ~s ticks fuel)\n" title max-ticks)
+       (printf "Testing ~s (engine with ~s ticks fuel)\n" title max-ticks)
        (let ((eng (make-engine (lambda () tested-expression))))
          (eng max-ticks
            (lambda (t v)


### PR DESCRIPTION
`test-divergence` was print this:

```
Testing ~s (engine with ~s ticks fuel)
omega10000000
```

This change makes it print this instead, which I think is what was intended.

```
Testing "omega" (engine with 10000000 ticks fuel)
```
