### PR TITLE
Fix some bugs

### DIFF
--- a/cKanren/src/infs.rkt
+++ b/cKanren/src/infs.rkt
@@ -3,7 +3,7 @@
 (require "helpers.rkt")
 
 ;; == STREAMS ==================================================================
-;; 
+;;
 ;; A Stream is an A-Inf
 ;; An A-Inf is one of:
 ;; - Inc
@@ -13,7 +13,7 @@
 ;; A Choiceg is a (cons Package-Internal A-Inf)
 ;; An Inc is a (lambda () A-Inf)
 
-(provide 
+(provide
  ;; Any Any Any Any Any -> Package-Internal
  ;; the parts of the Package are defined later, for now, they can be anything
  make-a/internal
@@ -38,10 +38,10 @@
 ;; the simple manifestations of the stream
 ;; (struct mzerof a-inf ())
 ;; (struct choiceg a-inf (a f))
-;; (struct inc a-inf (e) 
+;; (struct inc a-inf (e)
 ;;         #:property prop:procedure (struct-field-index e)
-;;         #:methods gen:custom-write 
-;;         [(define (write-proc i port mode) 
+;;         #:methods gen:custom-write
+;;         [(define (write-proc i port mode)
 ;;            ((parse-mode mode) "#<inc>" port))])
 
 (define mzerof (lambda () #f))
@@ -50,7 +50,7 @@
 (struct a #;a-inf (s c q t e)
         #:transparent
         #:extra-constructor-name make-a/internal
-        #:methods gen:custom-write 
+        #:methods gen:custom-write
         [(define (write-proc . args) (apply write-package args))])
 
 ;; controls how packages are displayed
@@ -93,13 +93,10 @@
      (let ((a-inf e))
        (cond
         [(not a-inf) e0]
-        [(procedure? a-inf) 
+        [(procedure? a-inf)
          (let ([f^ a-inf]) e1)]
         [(not (and (pair? a-inf)
                    (procedure? (cdr a-inf))))
          (let ([a^ a-inf]) e2)]
-        [else (let ([a (car a-inf)] [f (cdr a-inf)]) 
+        [else (let ([a (car a-inf)] [f (cdr a-inf)])
                 e3)])))))
-
-
-

--- a/cKanren/src/package.rkt
+++ b/cKanren/src/package.rkt
@@ -1,6 +1,6 @@
 #lang racket
 
-(require "constraint-store.rkt" "substitution.rkt" "queue.rkt" 
+(require "constraint-store.rkt" "substitution.rkt" "queue.rkt"
          "debugging.rkt" "infs.rkt" "events.rkt")
 
 (provide (struct-out path))
@@ -11,7 +11,7 @@
 (provide (all-from-out "debugging.rkt"))
 (provide empty-a)
 
-(provide 
+(provide
  #;
  (contract-out
   [make-a
@@ -26,8 +26,7 @@
 ;; == PACKAGE ==================================================================
 
 ;; the empty package
-(define empty-a 
+(define empty-a
   (make-a/internal empty-s empty-c empty-q empty-t empty-e))
 
 (define make-a make-a/internal)
-


### PR DESCRIPTION
Bug 1:
```
> (run* (q) (== q #f))
'()
```

In the definition of `case-inf`, the `cond`'s first branch:
```
[(not a-inf) e0]
```
When `q` was bound to #f, however, #f was regard as a kind of failure, then it was ignored.

So instead of putting the result directly into stream, it's better to encapsulate it with a list first.


Bug 2:
```
> (run 1.2 (q) (== q #t))
'(#t)
> (run -3 (q) (== q #t))
'(#t)
```

`take` should not accept negative number or float number.


Bug 3:
```
> (define teacupo
    (λ (x)
      (conde [(== 'tea x) succeed]
             [(== 'cup x) succeed]
             [fail])))
> (run* (r)
        (conde [(teacupo r) succeed]
               [(== 'f r) succeed]
               [fail]))
'(f tea cup)
```
It should return `'(tea cup #f) `.

On the Appendix A of `The Reasoned Schemer`, `mplus` and `mplusi` are defined like this:
```
(define mplus
  (λ (a-inf f)
    (case-inf a-inf
      (f)
      [(a) (choice a f)]
      [(a f0) (choice a (λf@ () (mplus (f0) f)))])))

(define mplusi
  (λ (a-inf f)
    (case-inf a-inf
      (f)
      [(a) (choice a f)]
      [(a f0) (choice a (λf@ () (mplusi (f) f0)))])))
```

We can see that `mplusm` is defined as `mplusi` instead of `mplus` in the old code.